### PR TITLE
No método hasNext da classe interna TrocoIterator, há um erro ao percorrer os índices do array papeisMoeda.

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -66,11 +66,12 @@ class Troco {
 
         @Override
         public boolean hasNext() {
-            for (int i = 6; i >= 0; i++) {
+            for (int i = 5; i >= 0; i--) { // índice máximo é 5
                 if (troco.papeisMoeda[i] != null) {
                     return true;
                 }
             }
+
             return false;
         }
 


### PR DESCRIPTION
…orrer os índices do array papeisMoeda.